### PR TITLE
Feat accommodationdetailview

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8f3795a0c6177277471296f986043fa1c80c65837ff75b290887e788121a0ece",
+  "originHash" : "5b01d12676ac82c34b08d04a2f85a6cb7a14bd2dc410345b6d4d99f2345d50ec",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
         "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "7deda23bbdca612076c5c315003d8638a08ed0f1",
+        "version" : "8.3.2"
       }
     },
     {

--- a/Dependenciese.swift
+++ b/Dependenciese.swift
@@ -16,6 +16,10 @@ let dependencies = Dependencies(
     .remote(
       url: "https://github.com/WenchaoD/FSCalendar",
       requirement: .upToNextMajor(from: "2.8.2")
+    ),
+    .remote(
+      url: "https://github.com/onevcat/Kingfisher.git",
+      requirement: .upToNextMajor(from: "7.0.0")
     )
   ],
   platforms: [.iOS]

--- a/FaceInn/Sources/Accommodation.swift
+++ b/FaceInn/Sources/Accommodation.swift
@@ -5,6 +5,7 @@
 //  Created by 신찬솔 on 5/18/25.
 //
 
+import Foundation
 
 struct Accommodation {
     let id: String
@@ -15,4 +16,17 @@ struct Accommodation {
     let reviewCount: Int
     let imageURLs: [String]?
     let rooms: [[String: Any]]?
+    var amenities: [String]?
+    var description: String?
+    let hostId: String?
+    var filteredRooms: [[String: Any]]? {
+        guard let rooms = rooms else { return nil }
+        let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+        return rooms.filter {
+            if let maxOccupancy = $0["maxOccupancy"] as? Int {
+                return maxOccupancy >= guestCount
+            }
+            return false
+        }
+    }
 }

--- a/FaceInn/Sources/AccommodationCardView.swift
+++ b/FaceInn/Sources/AccommodationCardView.swift
@@ -9,6 +9,7 @@ import UIKit
 import FirebaseStorage
 import FirebaseAuth
 import FirebaseFirestore
+import Kingfisher
 
 final class AccommodationCardView: UIView {
 
@@ -242,11 +243,6 @@ final class AccommodationCardView: UIView {
 
         if let urlString = model.imageURLs?.first, let url = URL(string: urlString) {
             print("📸 이미지 URL 시도: \(urlString)")
-            // Remove existing activity indicators
-            imageView.subviews.forEach { if $0 is UIActivityIndicatorView { $0.removeFromSuperview() } }
-
-            // Set loading animation before starting image load
-            imageView.image = nil
             let activity = UIActivityIndicatorView(style: .medium)
             activity.color = .darkGray
             activity.translatesAutoresizingMaskIntoConstraints = false
@@ -257,30 +253,18 @@ final class AccommodationCardView: UIView {
             ])
             activity.startAnimating()
 
-            URLSession.shared.dataTask(with: url) { data, _, error in
-                if let error = error {
-                    print("❌ 이미지 다운로드 실패: \(error.localizedDescription)")
-                    DispatchQueue.main.async {
-                        activity.stopAnimating()
-                        activity.removeFromSuperview()
-                    }
-                    return
-                }
-                guard let data = data else {
-                    print("❗️ 이미지 데이터가 없음")
-                    DispatchQueue.main.async {
-                        activity.stopAnimating()
-                        activity.removeFromSuperview()
-                    }
-                    return
-                }
+            imageView.kf.setImage(with: url, placeholder: nil, options: nil) { result in
                 DispatchQueue.main.async {
-                    self.imageView.image = UIImage(data: data)
                     activity.stopAnimating()
                     activity.removeFromSuperview()
-                    print("✅ 이미지 적용 완료")
                 }
-            }.resume()
+                switch result {
+                case .success:
+                    print("✅ 이미지 적용 완료")
+                case .failure(let error):
+                    print("❌ 이미지 다운로드 실패: \(error.localizedDescription)")
+                }
+            }
         } else {
             print("⚠️ imageURLs가 비었거나 잘못됨: \(model.imageURLs ?? [])")
         }

--- a/FaceInn/Sources/AccommodationDetailViewController .swift
+++ b/FaceInn/Sources/AccommodationDetailViewController .swift
@@ -6,8 +6,9 @@
 //
 
 import UIKit
+import Kingfisher
 
-final class AccommodationDetailViewController: UIViewController {
+final class AccommodationDetailViewController: UIViewController, UICollectionViewDataSource {
 
     var accommodation: Accommodation?
 
@@ -17,17 +18,111 @@ final class AccommodationDetailViewController: UIViewController {
         self.hidesBottomBarWhenPushed = true
         self.title = accommodation?.name
 
+        // Top image gallery
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 0
+        layout.itemSize = CGSize(width: view.bounds.width, height: 250)
 
-        let label = UILabel()
-        label.text = "숙소 상세 페이지"
-        label.font = .systemFont(ofSize: 18)
-        label.textColor = .black
-        label.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(label)
+        let imageGallery = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        imageGallery.translatesAutoresizingMaskIntoConstraints = false
+        imageGallery.isPagingEnabled = true
+        imageGallery.backgroundColor = .white
+        imageGallery.showsHorizontalScrollIndicator = false
+        imageGallery.dataSource = self
+        imageGallery.register(ImageCell.self, forCellWithReuseIdentifier: "ImageCell")
+        view.addSubview(imageGallery)
 
+        // Title Label
+        let titleLabel = UILabel()
+        titleLabel.text = accommodation?.name ?? "숙소 이름"
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(titleLabel)
+
+        // Address Label
+        let addressLabel = UILabel()
+        addressLabel.text = accommodation?.location ?? "주소 정보 없음"
+        addressLabel.font = UIFont.systemFont(ofSize: 16)
+        addressLabel.textColor = .darkGray
+        addressLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(addressLabel)
+
+        // Rating Label
+        let ratingLabel = UILabel()
+        if let rating = accommodation?.rating, let reviewCount = accommodation?.reviewCount {
+            ratingLabel.text = "⭐️ \(rating) (\(reviewCount)개 평가)"
+        } else {
+            ratingLabel.text = "⭐️ 평가 정보 없음"
+        }
+        ratingLabel.font = UIFont.systemFont(ofSize: 15)
+        ratingLabel.textColor = .darkGray
+        ratingLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(ratingLabel)
+
+        // Layout constraints
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            imageGallery.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            imageGallery.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageGallery.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageGallery.heightAnchor.constraint(equalToConstant: 250),
+
+            titleLabel.topAnchor.constraint(equalTo: imageGallery.bottomAnchor, constant: 16),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            addressLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            addressLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            addressLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+
+            ratingLabel.topAnchor.constraint(equalTo: addressLabel.bottomAnchor, constant: 8),
+            ratingLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            ratingLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
         ])
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return accommodation?.imageURLs?.count ?? 0
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ImageCell", for: indexPath) as? ImageCell else {
+            return UICollectionViewCell()
+        }
+
+        if let urlString = accommodation?.imageURLs?[indexPath.item], let url = URL(string: urlString) {
+            cell.configure(with: url)
+        }
+
+        return cell
+    }
+}
+
+final class ImageCell: UICollectionViewCell {
+    private let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with url: URL) {
+        imageView.kf.setImage(with: url)
     }
 }

--- a/FaceInn/Sources/AccommodationDetailViewController .swift
+++ b/FaceInn/Sources/AccommodationDetailViewController .swift
@@ -17,6 +17,8 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
     private let scrollView = UIScrollView()
     private let contentView = UIView()
 
+    private let roomCardsStackView = UIStackView()
+
     var accommodation: Accommodation?
 
     private static var lastDisplayedRooms: [AccommodationRoom] = []
@@ -212,114 +214,22 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
             guestButton.widthAnchor.constraint(equalToConstant: 120)
         ])
 
-        var lastBottomAnchor: NSLayoutYAxisAnchor = guestButton.bottomAnchor
-        let startDate = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date
-        let endDate = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date
-        let numberOfNights = Calendar.current.dateComponents([.day], from: startDate ?? Date(), to: endDate ?? Date()).day ?? 1
-        if let rooms = accommodation?.rooms {
-            let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+        // Room cards stack view
+        roomCardsStackView.axis = .vertical
+        roomCardsStackView.spacing = 20
+        roomCardsStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(roomCardsStackView)
 
-            var availableRooms: [AccommodationRoom] = []
-            var unavailableRooms: [AccommodationRoom] = []
+        NSLayoutConstraint.activate([
+            roomCardsStackView.topAnchor.constraint(equalTo: guestButton.bottomAnchor, constant: 20),
+            roomCardsStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            roomCardsStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
+        ])
 
-            for roomDict in rooms {
-                if let id = roomDict["id"] as? String,
-                   let name = roomDict["name"] as? String,
-                   let description = roomDict["description"] as? String,
-                   let price = roomDict["price"] as? Int,
-                   let maxOccupancy = roomDict["maxOccupancy"] as? Int,
-                   let imageURLs = roomDict["imageURLs"] as? [String],
-                   let checkInTime = roomDict["checkInTime"] as? String,
-                   let checkOutTime = roomDict["checkOutTime"] as? String,
-                   let amenities = roomDict["amenities"] as? [String] {
+        // Load room cards
+        reloadRoomCardsSafely()
 
-                    let room = AccommodationRoom(
-                        id: id,
-                        name: name,
-                        description: description,
-                        price: price,
-                        maxOccupancy: maxOccupancy,
-                        imageURLs: imageURLs,
-                        checkInTime: checkInTime,
-                        checkOutTime: checkOutTime,
-                        amenities: amenities
-                    )
-
-                    if guestCount <= maxOccupancy {
-                        availableRooms.append(room)
-                    } else {
-                        unavailableRooms.append(room)
-                    }
-                }
-            }
-
-            availableRooms.sort { $0.price < $1.price }
-            let sortedRooms = availableRooms + unavailableRooms
-
-            // Refactored shouldForceReload logic block
-            let shouldForceReload: Bool
-            if let start = startDate, let end = endDate,
-               let lastStart = AccommodationDetailViewController.lastSelectedStartDate,
-               let lastEnd = AccommodationDetailViewController.lastSelectedEndDate {
-                let currentNights = Calendar.current.dateComponents([.day], from: start, to: end).day ?? 1
-                let lastNights = Calendar.current.dateComponents([.day], from: lastStart, to: lastEnd).day ?? 1
-                shouldForceReload = currentNights != lastNights
-            } else if startDate != nil && endDate != nil {
-                shouldForceReload = true
-            } else {
-                shouldForceReload = false
-            }
-
-            if sortedRooms == AccommodationDetailViewController.lastDisplayedRooms && !shouldForceReload {
-                return
-            }
-
-            AccommodationDetailViewController.lastDisplayedRooms = sortedRooms
-            AccommodationDetailViewController.lastSelectedStartDate = startDate
-            AccommodationDetailViewController.lastSelectedEndDate = endDate
-            AccommodationDetailViewController.lastSelectedGuestCount = guestCount
-
-            for room in sortedRooms {
-                let roomCard = RoomCardView(room: room, numberOfNights: numberOfNights)
-                roomCard.translatesAutoresizingMaskIntoConstraints = false
-                roomCard.updateGuestCount(guestCount)
-                roomCard.onReserveButtonTapped = { [weak self] room in
-                    guard let self = self, let accommodation = self.accommodation else { return }
-
-                    let reservationVC = ReservationViewController()
-                    reservationVC.accommodation = accommodation
-                    reservationVC.room = room
-
-                    // 숙박 날짜, 박 수, 숙박 인원 전달
-                    if let start = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date,
-                       let end = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date {
-                        reservationVC.startDate = start
-                        reservationVC.endDate = end
-                    }
-
-                    let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
-                    reservationVC.guestCount = guestCount
-
-                    self.navigationController?.pushViewController(reservationVC, animated: true)
-                }
-                roomCard.alpha = 0
-                roomCard.transform = CGAffineTransform(translationX: 0, y: 30)
-                contentView.addSubview(roomCard)
-
-                NSLayoutConstraint.activate([
-                    roomCard.topAnchor.constraint(equalTo: lastBottomAnchor, constant: 20),
-                    roomCard.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-                    roomCard.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
-                ])
-                contentView.layoutIfNeeded()
-                UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseOut], animations: {
-                    roomCard.alpha = 1
-                    roomCard.transform = .identity
-                }, completion: nil)
-
-                lastBottomAnchor = roomCard.bottomAnchor
-            }
-        }
+        var lastBottomAnchor: NSLayoutYAxisAnchor = roomCardsStackView.bottomAnchor
 
         if let introduction = accommodation?.description {
             let introductionTitleLabel = UILabel()
@@ -428,9 +338,7 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
                 UserDefaults.standard.set(start, forKey: "selectedStartDate")
                 UserDefaults.standard.removeObject(forKey: "selectedEndDate")
             }
-        
-            self.view.subviews.forEach { $0.removeFromSuperview() }
-            self.viewDidLoad()
+            self.reloadRoomCardsSafely()
         }
         present(vc, animated: true)
     }
@@ -451,11 +359,98 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
             UserDefaults.standard.set(totalGuests, forKey: "selectedGuestCount")
             
             DispatchQueue.main.async {
-                self.view.subviews.forEach { $0.removeFromSuperview() }
-                self.viewDidLoad()
+                self.reloadRoomCardsSafely()
             }
         }
         present(vc, animated: true)
+    }
+
+    private func reloadRoomCardsSafely() {
+        roomCardsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        let guestCount = UserDefaults.standard.object(forKey: "selectedGuestCount") != nil
+            ? UserDefaults.standard.integer(forKey: "selectedGuestCount")
+            : 2
+
+        let startDate = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date ?? Date()
+        let endDate = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+
+        let numberOfNights = Calendar.current.dateComponents([.day], from: startDate, to: endDate).day ?? 1
+
+        guard let rooms = accommodation?.rooms else { return }
+
+        var availableRooms: [AccommodationRoom] = []
+        var unavailableRooms: [AccommodationRoom] = []
+
+        for roomDict in rooms {
+            if let id = roomDict["id"] as? String,
+               let name = roomDict["name"] as? String,
+               let description = roomDict["description"] as? String,
+               let price = roomDict["price"] as? Int,
+               let maxOccupancy = roomDict["maxOccupancy"] as? Int,
+               let imageURLs = roomDict["imageURLs"] as? [String],
+               let checkInTime = roomDict["checkInTime"] as? String,
+               let checkOutTime = roomDict["checkOutTime"] as? String,
+               let amenities = roomDict["amenities"] as? [String] {
+
+                let room = AccommodationRoom(
+                    id: id,
+                    name: name,
+                    description: description,
+                    price: price,
+                    maxOccupancy: maxOccupancy,
+                    imageURLs: imageURLs,
+                    checkInTime: checkInTime,
+                    checkOutTime: checkOutTime,
+                    amenities: amenities
+                )
+
+                if guestCount <= maxOccupancy {
+                    availableRooms.append(room)
+                } else {
+                    unavailableRooms.append(room)
+                }
+            }
+        }
+
+        availableRooms.sort { $0.price < $1.price }
+        let sortedRooms = availableRooms + unavailableRooms
+
+        for (index, room) in sortedRooms.enumerated() {
+            let roomCard = RoomCardView(room: room, numberOfNights: numberOfNights)
+            roomCard.translatesAutoresizingMaskIntoConstraints = false
+            roomCard.updateGuestCount(guestCount)
+            roomCard.alpha = 0
+            roomCard.transform = CGAffineTransform(translationX: 0, y: 20)
+
+            roomCard.onReserveButtonTapped = { [weak self] room in
+                guard let self = self, let accommodation = self.accommodation else { return }
+
+                let reservationVC = ReservationViewController()
+                reservationVC.accommodation = accommodation
+                reservationVC.room = room
+                reservationVC.startDate = startDate
+                reservationVC.endDate = endDate
+                reservationVC.guestCount = guestCount
+
+                self.navigationController?.pushViewController(reservationVC, animated: true)
+            }
+
+            roomCardsStackView.addArrangedSubview(roomCard)
+
+            UIView.animate(withDuration: 0.3, delay: 0.05 * Double(index), options: [.curveEaseOut], animations: {
+                roomCard.alpha = 1
+                roomCard.transform = .identity
+            }, completion: nil)
+        }
+
+        if sortedRooms.isEmpty {
+            let label = UILabel()
+            label.text = "조건에 맞는 객실이 없습니다"
+            label.textAlignment = .center
+            label.textColor = .gray
+            roomCardsStackView.addArrangedSubview(label)
+        }
     }
 }
 

--- a/FaceInn/Sources/AccommodationDetailViewController .swift
+++ b/FaceInn/Sources/AccommodationDetailViewController .swift
@@ -20,6 +20,9 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
     var accommodation: Accommodation?
 
     private static var lastDisplayedRooms: [AccommodationRoom] = []
+    private static var lastSelectedStartDate: Date?
+    private static var lastSelectedEndDate: Date?
+    private static var lastSelectedGuestCount: Int?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -253,11 +256,28 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
             availableRooms.sort { $0.price < $1.price }
             let sortedRooms = availableRooms + unavailableRooms
 
-            if sortedRooms == AccommodationDetailViewController.lastDisplayedRooms {
-                return
+            // Refactored shouldForceReload logic block
+            let shouldForceReload: Bool
+            if let start = startDate, let end = endDate,
+               let lastStart = AccommodationDetailViewController.lastSelectedStartDate,
+               let lastEnd = AccommodationDetailViewController.lastSelectedEndDate {
+                let currentNights = Calendar.current.dateComponents([.day], from: start, to: end).day ?? 1
+                let lastNights = Calendar.current.dateComponents([.day], from: lastStart, to: lastEnd).day ?? 1
+                shouldForceReload = currentNights != lastNights
+            } else if startDate != nil && endDate != nil {
+                shouldForceReload = true
             } else {
-                AccommodationDetailViewController.lastDisplayedRooms = sortedRooms
+                shouldForceReload = false
             }
+
+            if sortedRooms == AccommodationDetailViewController.lastDisplayedRooms && !shouldForceReload {
+                return
+            }
+
+            AccommodationDetailViewController.lastDisplayedRooms = sortedRooms
+            AccommodationDetailViewController.lastSelectedStartDate = startDate
+            AccommodationDetailViewController.lastSelectedEndDate = endDate
+            AccommodationDetailViewController.lastSelectedGuestCount = guestCount
 
             for room in sortedRooms {
                 let roomCard = RoomCardView(room: room, numberOfNights: numberOfNights)

--- a/FaceInn/Sources/AccommodationDetailViewController .swift
+++ b/FaceInn/Sources/AccommodationDetailViewController .swift
@@ -7,10 +7,19 @@
 
 import UIKit
 import Kingfisher
+import FirebaseFirestore
 
 final class AccommodationDetailViewController: UIViewController, UICollectionViewDataSource {
 
+    // 예약 버튼 탭 클로저 타입 명시
+    private var onReserveButtonTapped: ((AccommodationRoom) -> Void)?
+
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+
     var accommodation: Accommodation?
+
+    private static var lastDisplayedRooms: [AccommodationRoom] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,7 +27,24 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
         self.hidesBottomBarWhenPushed = true
         self.title = accommodation?.name
 
-        // Top image gallery
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
@@ -31,24 +57,21 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
         imageGallery.showsHorizontalScrollIndicator = false
         imageGallery.dataSource = self
         imageGallery.register(ImageCell.self, forCellWithReuseIdentifier: "ImageCell")
-        view.addSubview(imageGallery)
+        contentView.addSubview(imageGallery)
 
-        // Title Label
         let titleLabel = UILabel()
         titleLabel.text = accommodation?.name ?? "숙소 이름"
         titleLabel.font = UIFont.boldSystemFont(ofSize: 22)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(titleLabel)
+        contentView.addSubview(titleLabel)
 
-        // Address Label
         let addressLabel = UILabel()
         addressLabel.text = accommodation?.location ?? "주소 정보 없음"
         addressLabel.font = UIFont.systemFont(ofSize: 16)
         addressLabel.textColor = .darkGray
         addressLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(addressLabel)
+        contentView.addSubview(addressLabel)
 
-        // Rating Label
         let ratingLabel = UILabel()
         if let rating = accommodation?.rating, let reviewCount = accommodation?.reviewCount {
             ratingLabel.text = "⭐️ \(rating) (\(reviewCount)개 평가)"
@@ -58,18 +81,96 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
         ratingLabel.font = UIFont.systemFont(ofSize: 15)
         ratingLabel.textColor = .darkGray
         ratingLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(ratingLabel)
+        contentView.addSubview(ratingLabel)
 
-        // Layout constraints
+        let separator = UIView()
+        separator.backgroundColor = .lightGray
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separator)
+
+        let amenitiesTitleLabel = UILabel()
+        amenitiesTitleLabel.text = "편의시설"
+        amenitiesTitleLabel.font = UIFont.boldSystemFont(ofSize: 18)
+        amenitiesTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(amenitiesTitleLabel)
+
+        let amenitiesStackView = UIStackView()
+        amenitiesStackView.axis = .vertical
+        amenitiesStackView.spacing = 6
+        amenitiesStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        if let amenities = accommodation?.amenities {
+            for item in amenities {
+                let label = UILabel()
+                label.text = "• \(item)"
+                label.font = UIFont.systemFont(ofSize: 15)
+                label.textColor = .darkGray
+                amenitiesStackView.addArrangedSubview(label)
+            }
+        }
+
+        contentView.addSubview(amenitiesStackView)
+
+        let amenitiesBottomSeparator = UIView()
+        amenitiesBottomSeparator.backgroundColor = .lightGray
+        amenitiesBottomSeparator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(amenitiesBottomSeparator)
+
+        let bottomSeparator = UIView()
+        bottomSeparator.backgroundColor = .lightGray
+        bottomSeparator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(bottomSeparator)
+
+        let dateButton = UIButton(type: .system)
+        dateButton.setTitle("📅 날짜 선택", for: .normal)
+        dateButton.contentHorizontalAlignment = .center
+        dateButton.tintColor = .black
+        dateButton.layer.cornerRadius = 8
+        dateButton.layer.borderWidth = 1
+        dateButton.layer.borderColor = UIColor(red: 47/255, green: 175/255, blue: 83/255, alpha: 1).cgColor
+        dateButton.backgroundColor = .white
+        dateButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
+        dateButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        dateButton.translatesAutoresizingMaskIntoConstraints = false
+        dateButton.addTarget(self, action: #selector(dateButtonTapped(_:)), for: .touchUpInside)
+        contentView.addSubview(dateButton)
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일"
+        if let start = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date,
+           let end = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date {
+            let title = "📅 \(formatter.string(from: start)) - \(formatter.string(from: end))"
+            dateButton.setTitle(title, for: .normal)
+        }
+
+        let guestButton = UIButton(type: .system)
+        guestButton.setTitle("👥 인원 선택", for: .normal)
+        guestButton.contentHorizontalAlignment = .center
+        guestButton.tintColor = .black
+        guestButton.layer.cornerRadius = 8
+        guestButton.layer.borderWidth = 1
+        guestButton.layer.borderColor = UIColor(red: 47/255, green: 175/255, blue: 83/255, alpha: 1).cgColor
+        guestButton.backgroundColor = .white
+        guestButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 14)
+        guestButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        guestButton.translatesAutoresizingMaskIntoConstraints = false
+        guestButton.addTarget(self, action: #selector(guestButtonTapped(_:)), for: .touchUpInside)
+        contentView.addSubview(guestButton)
+
+        let savedGuestCount = UserDefaults.standard.object(forKey: "selectedGuestCount") != nil ?
+            UserDefaults.standard.integer(forKey: "selectedGuestCount") : 2
+        guestButton.setTitle("👥 \(savedGuestCount)명", for: .normal)
+
         NSLayoutConstraint.activate([
-            imageGallery.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            imageGallery.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageGallery.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageGallery.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageGallery.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageGallery.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             imageGallery.heightAnchor.constraint(equalToConstant: 250),
 
             titleLabel.topAnchor.constraint(equalTo: imageGallery.bottomAnchor, constant: 16),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
 
             addressLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
             addressLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
@@ -78,6 +179,193 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
             ratingLabel.topAnchor.constraint(equalTo: addressLabel.bottomAnchor, constant: 8),
             ratingLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             ratingLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+
+            separator.topAnchor.constraint(equalTo: ratingLabel.bottomAnchor, constant: 20),
+            separator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            separator.heightAnchor.constraint(equalToConstant: 1),
+
+            amenitiesTitleLabel.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 12),
+            amenitiesTitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            amenitiesTitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+
+            amenitiesStackView.topAnchor.constraint(equalTo: amenitiesTitleLabel.bottomAnchor, constant: 8),
+            amenitiesStackView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            amenitiesStackView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+
+            amenitiesBottomSeparator.topAnchor.constraint(equalTo: amenitiesStackView.bottomAnchor, constant: 16),
+            amenitiesBottomSeparator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            amenitiesBottomSeparator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            amenitiesBottomSeparator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+
+        NSLayoutConstraint.activate([
+            dateButton.topAnchor.constraint(equalTo: amenitiesBottomSeparator.bottomAnchor, constant: 20),
+            dateButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            dateButton.widthAnchor.constraint(equalToConstant: 200),
+
+            guestButton.topAnchor.constraint(equalTo: dateButton.topAnchor),
+            guestButton.leadingAnchor.constraint(equalTo: dateButton.trailingAnchor, constant: 12),
+            guestButton.widthAnchor.constraint(equalToConstant: 120)
+        ])
+
+        var lastBottomAnchor: NSLayoutYAxisAnchor = guestButton.bottomAnchor
+        let startDate = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date
+        let endDate = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date
+        let numberOfNights = Calendar.current.dateComponents([.day], from: startDate ?? Date(), to: endDate ?? Date()).day ?? 1
+        if let rooms = accommodation?.rooms {
+            let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+
+            var availableRooms: [AccommodationRoom] = []
+            var unavailableRooms: [AccommodationRoom] = []
+
+            for roomDict in rooms {
+                if let id = roomDict["id"] as? String,
+                   let name = roomDict["name"] as? String,
+                   let description = roomDict["description"] as? String,
+                   let price = roomDict["price"] as? Int,
+                   let maxOccupancy = roomDict["maxOccupancy"] as? Int,
+                   let imageURLs = roomDict["imageURLs"] as? [String],
+                   let checkInTime = roomDict["checkInTime"] as? String,
+                   let checkOutTime = roomDict["checkOutTime"] as? String,
+                   let amenities = roomDict["amenities"] as? [String] {
+
+                    let room = AccommodationRoom(
+                        id: id,
+                        name: name,
+                        description: description,
+                        price: price,
+                        maxOccupancy: maxOccupancy,
+                        imageURLs: imageURLs,
+                        checkInTime: checkInTime,
+                        checkOutTime: checkOutTime,
+                        amenities: amenities
+                    )
+
+                    if guestCount <= maxOccupancy {
+                        availableRooms.append(room)
+                    } else {
+                        unavailableRooms.append(room)
+                    }
+                }
+            }
+
+            availableRooms.sort { $0.price < $1.price }
+            let sortedRooms = availableRooms + unavailableRooms
+
+            if sortedRooms == AccommodationDetailViewController.lastDisplayedRooms {
+                return
+            } else {
+                AccommodationDetailViewController.lastDisplayedRooms = sortedRooms
+            }
+
+            for room in sortedRooms {
+                let roomCard = RoomCardView(room: room, numberOfNights: numberOfNights)
+                roomCard.translatesAutoresizingMaskIntoConstraints = false
+                roomCard.updateGuestCount(guestCount)
+                roomCard.onReserveButtonTapped = { [weak self] room in
+                    guard let self = self, let accommodation = self.accommodation else { return }
+
+                    let reservationVC = ReservationViewController()
+                    reservationVC.accommodation = accommodation
+                    reservationVC.room = room
+
+                    // 숙박 날짜, 박 수, 숙박 인원 전달
+                    if let start = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date,
+                       let end = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date {
+                        reservationVC.startDate = start
+                        reservationVC.endDate = end
+                    }
+
+                    let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+                    reservationVC.guestCount = guestCount
+
+                    self.navigationController?.pushViewController(reservationVC, animated: true)
+                }
+                roomCard.alpha = 0
+                roomCard.transform = CGAffineTransform(translationX: 0, y: 30)
+                contentView.addSubview(roomCard)
+
+                NSLayoutConstraint.activate([
+                    roomCard.topAnchor.constraint(equalTo: lastBottomAnchor, constant: 20),
+                    roomCard.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+                    roomCard.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
+                ])
+                contentView.layoutIfNeeded()
+                UIView.animate(withDuration: 0.35, delay: 0, options: [.curveEaseOut], animations: {
+                    roomCard.alpha = 1
+                    roomCard.transform = .identity
+                }, completion: nil)
+
+                lastBottomAnchor = roomCard.bottomAnchor
+            }
+        }
+
+        if let introduction = accommodation?.description {
+            let introductionTitleLabel = UILabel()
+            introductionTitleLabel.text = "숙소 소개"
+            introductionTitleLabel.font = UIFont.boldSystemFont(ofSize: 18)
+            introductionTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(introductionTitleLabel)
+
+            let introductionLabel = UILabel()
+            introductionLabel.text = introduction
+            introductionLabel.font = UIFont.systemFont(ofSize: 15)
+            introductionLabel.textColor = .darkGray
+            introductionLabel.numberOfLines = 0
+            introductionLabel.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(introductionLabel)
+
+            NSLayoutConstraint.activate([
+                introductionTitleLabel.topAnchor.constraint(equalTo: lastBottomAnchor, constant: 24),
+                introductionTitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+                introductionTitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+
+                introductionLabel.topAnchor.constraint(equalTo: introductionTitleLabel.bottomAnchor, constant: 8),
+                introductionLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+                introductionLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
+            ])
+
+            lastBottomAnchor = introductionLabel.bottomAnchor
+        }
+
+        NSLayoutConstraint.activate([
+            bottomSeparator.topAnchor.constraint(equalTo: lastBottomAnchor, constant: 20),
+            bottomSeparator.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            bottomSeparator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            bottomSeparator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+
+        // 판매자 정보 버튼 추가
+        let sellerInfoButton = UIButton(type: .system)
+        sellerInfoButton.setTitle("판매자 정보", for: .normal)
+        sellerInfoButton.setTitleColor(.black, for: .normal)
+        sellerInfoButton.contentHorizontalAlignment = .left
+        sellerInfoButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+        sellerInfoButton.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
+        sellerInfoButton.backgroundColor = UIColor(red: 247/255, green: 248/255, blue: 250/255, alpha: 1)
+        sellerInfoButton.layer.cornerRadius = 8
+        sellerInfoButton.addTarget(self, action: #selector(sellerInfoTapped), for: .touchUpInside)
+        sellerInfoButton.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(sellerInfoButton)
+
+        let arrowImageView = UIImageView(image: UIImage(systemName: "chevron.right"))
+        arrowImageView.tintColor = .lightGray
+        arrowImageView.translatesAutoresizingMaskIntoConstraints = false
+        sellerInfoButton.addSubview(arrowImageView)
+
+        NSLayoutConstraint.activate([
+            sellerInfoButton.topAnchor.constraint(equalTo: bottomSeparator.bottomAnchor, constant: 16),
+            sellerInfoButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            sellerInfoButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            sellerInfoButton.heightAnchor.constraint(equalToConstant: 60),
+
+            arrowImageView.centerYAnchor.constraint(equalTo: sellerInfoButton.centerYAnchor),
+            arrowImageView.trailingAnchor.constraint(equalTo: sellerInfoButton.trailingAnchor, constant: -16),
+            arrowImageView.widthAnchor.constraint(equalToConstant: 12),
+            arrowImageView.heightAnchor.constraint(equalToConstant: 20),
+
+            sellerInfoButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -30)
         ])
     }
 
@@ -95,6 +383,59 @@ final class AccommodationDetailViewController: UIViewController, UICollectionVie
         }
 
         return cell
+    }
+    
+    @objc private func dateButtonTapped(_ sender: UIButton) {
+        let vc = DatePickerPopoverViewController()
+        vc.modalPresentationStyle = .automatic
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+        vc.onDateSelected = { [weak self, weak sender] startDate, endDate in
+            guard let self = self else { return }
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "ko_KR")
+            formatter.dateFormat = "M월 d일"
+            if let start = startDate, let end = endDate {
+                let title = "📅 \(formatter.string(from: start)) - \(formatter.string(from: end))"
+                sender?.setTitle(title, for: .normal)
+                UserDefaults.standard.set(start, forKey: "selectedStartDate")
+                UserDefaults.standard.set(end, forKey: "selectedEndDate")
+            } else if let start = startDate {
+                let title = "📅 \(formatter.string(from: start))"
+                sender?.setTitle(title, for: .normal)
+                UserDefaults.standard.set(start, forKey: "selectedStartDate")
+                UserDefaults.standard.removeObject(forKey: "selectedEndDate")
+            }
+        
+            self.view.subviews.forEach { $0.removeFromSuperview() }
+            self.viewDidLoad()
+        }
+        present(vc, animated: true)
+    }
+
+    @objc private func guestButtonTapped(_ sender: UIButton) {
+        let vc = GuestSelectorViewController()
+        vc.modalPresentationStyle = .automatic
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom(resolver: { _ in return 130 })]
+            sheet.prefersGrabberVisible = true
+        }
+        vc.onGuestsSelected = { [weak self, weak sender] adults, children in
+            guard let self else { return }
+            let totalGuests = adults + children
+            sender?.setTitle("👥 \(totalGuests)명", for: .normal)
+            UserDefaults.standard.set(adults, forKey: "selectedAdults")
+            UserDefaults.standard.set(children, forKey: "selectedChildren")
+            UserDefaults.standard.set(totalGuests, forKey: "selectedGuestCount")
+            
+            DispatchQueue.main.async {
+                self.view.subviews.forEach { $0.removeFromSuperview() }
+                self.viewDidLoad()
+            }
+        }
+        present(vc, animated: true)
     }
 }
 
@@ -124,5 +465,16 @@ final class ImageCell: UICollectionViewCell {
 
     func configure(with url: URL) {
         imageView.kf.setImage(with: url)
+    }
+}
+
+extension AccommodationDetailViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .none
+    }
+    @objc private func sellerInfoTapped() {
+        let vc = HostProfileViewController()
+        vc.hostId = self.accommodation?.hostId ?? ""
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/FaceInn/Sources/AccommodationRoom.swift
+++ b/FaceInn/Sources/AccommodationRoom.swift
@@ -1,0 +1,22 @@
+//
+//  Room.swift
+//  FaceInn
+//
+//  Created by 신찬솔 on 5/21/25.
+//
+
+
+
+import Foundation
+
+struct AccommodationRoom: Codable, Equatable {
+    let id: String
+    let name: String
+    let description: String
+    let price: Int
+    let maxOccupancy: Int
+    let imageURLs: [String]
+    let checkInTime: String
+    let checkOutTime: String
+    let amenities: [String]
+}

--- a/FaceInn/Sources/AppDelegate.swift
+++ b/FaceInn/Sources/AppDelegate.swift
@@ -34,6 +34,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("❌ 로그인된 사용자 없음")
         }
         
+        let barAppearance = UIBarButtonItem.appearance()
+        barAppearance.setBackButtonTitlePositionAdjustment(UIOffset(horizontal: -1000, vertical: 0), for: .default)
         return true
     }
     

--- a/FaceInn/Sources/HomeViewController.swift
+++ b/FaceInn/Sources/HomeViewController.swift
@@ -274,7 +274,10 @@ final class HomeViewController: UIViewController {
                     rating: data["rating"] as? Double ?? 0.0,
                     reviewCount: data["reviewCount"] as? Int ?? 0,
                     imageURLs: data["imageURLs"] as? [String],
-                    rooms: data["rooms"] as? [[String: Any]]
+                    rooms: data["rooms"] as? [[String: Any]],
+                    amenities: data["amenities"] as? [String],
+                    description: data["description"] as? String ?? "",
+                    hostId: data["hostId"] as? String ?? ""
                 )
             }
             let guestCount = UserDefaults.standard.object(forKey: "selectedGuestCount") != nil ?

--- a/FaceInn/Sources/HomeViewController.swift
+++ b/FaceInn/Sources/HomeViewController.swift
@@ -309,6 +309,25 @@ final class HomeViewController: UIViewController {
     @objc private func dismissKeyboard() {
         view.endEditing(true)
     }
+
+    private func updateDateAndGuestButtonTitles() {
+        if let guestButton = filterStackView.arrangedSubviews[2] as? UIButton {
+            let savedGuestCount = UserDefaults.standard.object(forKey: "selectedGuestCount") != nil ?
+                UserDefaults.standard.integer(forKey: "selectedGuestCount") : 2
+            guestButton.setTitle("👥 \(savedGuestCount)명", for: .normal)
+        }
+
+        if let dateButton = filterStackView.arrangedSubviews[1] as? UIButton {
+            if let start = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date,
+               let end = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date {
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "ko_KR")
+                formatter.dateFormat = "M월 d일"
+                let title = "📅 \(formatter.string(from: start)) - \(formatter.string(from: end))"
+                dateButton.setTitle(title, for: .normal)
+            }
+        }
+    }
 }
 
 extension HomeViewController: UICollectionViewDataSource {
@@ -376,6 +395,7 @@ extension HomeViewController: UISearchBarDelegate {
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        updateDateAndGuestButtonTitles()
         fetchAccommodations()
     }
 }

--- a/FaceInn/Sources/HostProfileViewControlle.swift
+++ b/FaceInn/Sources/HostProfileViewControlle.swift
@@ -1,0 +1,33 @@
+//
+//  HostProfileViewControlle.swift
+//  FaceInn
+//
+//  Created by 신찬솔 on 5/21/25.
+//
+
+
+import UIKit
+
+final class HostProfileViewController: UIViewController {
+
+    var hostId: String = ""
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.title = "판매자 정보"
+        view.backgroundColor = .white
+
+        let hostIDLabel = UILabel()
+        hostIDLabel.text = "Host ID: \(hostId)"
+        hostIDLabel.textAlignment = .center
+        hostIDLabel.font = UIFont.systemFont(ofSize: 20)
+        hostIDLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(hostIDLabel)
+
+        NSLayoutConstraint.activate([
+            hostIDLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            hostIDLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+}

--- a/FaceInn/Sources/ImageGalleryCell.swift
+++ b/FaceInn/Sources/ImageGalleryCell.swift
@@ -1,0 +1,48 @@
+//
+//  ImageGalleryCell.swift
+//  FaceInn
+//
+//  Created by 신찬솔 on 5/21/25.
+//
+
+import UIKit
+import Kingfisher
+
+class ImageGalleryCell: UICollectionViewCell {
+    static let identifier = "ImageGalleryCell"
+
+    let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        imageView.kf.setImage(
+            with: url,
+            placeholder: UIImage(systemName: "photo"),
+            options: [
+                .transition(.fade(0.2)),
+                .cacheOriginalImage
+            ]
+        )
+    }
+}

--- a/FaceInn/Sources/ReservationViewController.swift
+++ b/FaceInn/Sources/ReservationViewController.swift
@@ -1,0 +1,75 @@
+//
+//  ReservationViewController.swift
+//  FaceInn
+//
+//  Created by 신찬솔 on 5/21/25.
+//
+
+
+import UIKit
+
+final class ReservationViewController: UIViewController {
+    
+    var accommodation: Accommodation?
+    var room: AccommodationRoom?
+    var startDate: Date?
+    var endDate: Date?
+    var guestCount: Int?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "예약"
+
+        assert(accommodation != nil, "❌ accommodation 정보가 nil입니다.")
+        assert(room != nil, "❌ room 정보가 nil입니다.")
+        print("✅ 예약 정보 수신 확인 - 숙소명: \(accommodation?.name ?? "nil"), 객실명: \(room?.name ?? "nil")")
+
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        if let accommodation = accommodation,
+           let room = room,
+           let startDate = UserDefaults.standard.object(forKey: "selectedStartDate") as? Date,
+           let endDate = UserDefaults.standard.object(forKey: "selectedEndDate") as? Date {
+
+            let calendar = Calendar.current
+            let numberOfNights = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 1
+            let totalPrice = room.price * numberOfNights
+            let formattedTotal = totalPrice.formattedWithSeparator
+            let guestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy년 M월 d일"
+            let dateRange = "\(formatter.string(from: startDate)) - \(formatter.string(from: endDate))"
+
+            label.text = """
+             \(accommodation.name)
+             \(room.name)
+             \(dateRange)
+             \(numberOfNights)박
+             ₩\(formattedTotal)
+             \(guestCount)명
+            """
+        } else {
+            label.text = "예약 페이지"
+        }
+
+        view.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+}
+
+private extension Int {
+    var formattedWithSeparator: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+    }
+}

--- a/FaceInn/Sources/RoomCardView.swift
+++ b/FaceInn/Sources/RoomCardView.swift
@@ -1,0 +1,187 @@
+//
+//  RoomCardView.swift
+//  FaceInn
+//
+//  Created by 신찬솔 on 5/21/25.
+//
+
+import UIKit
+import Kingfisher
+
+final class RoomCardView: UIView {
+
+    // Closure called when reserve button is tapped
+    var onReserveButtonTapped: ((AccommodationRoom) -> Void)?
+
+    private var numberOfNights: Int = 1
+
+    private let scrollView = UIScrollView()
+    private let imageStackView = UIStackView()
+    private let nameLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private var occupancyLabel = UILabel()
+    private var amenitiesLabel = UILabel()
+    private let checkInOutLabel = UILabel()
+    private let priceLabel = UILabel()
+    private let reserveButton = UIButton(type: .system)
+    private var currentRoom: AccommodationRoom?
+
+    init(room: AccommodationRoom, numberOfNights: Int) {
+        super.init(frame: .zero)
+        setupView()
+        configure(with: room, numberOfNights: numberOfNights)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        layer.cornerRadius = 12
+        backgroundColor = .white
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.1
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+        layer.shadowRadius = 4
+
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        imageStackView.axis = .horizontal
+        imageStackView.distribution = .fillEqually
+        imageStackView.spacing = 0
+        imageStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        scrollView.addSubview(imageStackView)
+        addSubview(scrollView)
+
+        nameLabel.font = .boldSystemFont(ofSize: 18)
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        descriptionLabel.font = .systemFont(ofSize: 14)
+        descriptionLabel.textColor = .darkGray
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let occupancyLabel = UILabel()
+        occupancyLabel.font = .systemFont(ofSize: 14)
+        occupancyLabel.textColor = .darkGray
+        occupancyLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.occupancyLabel = occupancyLabel
+
+        let amenitiesLabel = UILabel()
+        amenitiesLabel.font = .systemFont(ofSize: 13)
+        amenitiesLabel.textColor = .gray
+        amenitiesLabel.numberOfLines = 1
+        amenitiesLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.amenitiesLabel = amenitiesLabel
+
+        checkInOutLabel.font = .systemFont(ofSize: 13)
+        checkInOutLabel.textColor = .gray
+        checkInOutLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        priceLabel.font = .boldSystemFont(ofSize: 16)
+        priceLabel.textColor = .black
+        priceLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        reserveButton.setTitle("숙박 예약", for: .normal)
+        reserveButton.backgroundColor = UIColor(red: 47/255, green: 175/255, blue: 83/255, alpha: 1)
+        reserveButton.tintColor = .white
+        reserveButton.layer.cornerRadius = 6
+        reserveButton.translatesAutoresizingMaskIntoConstraints = false
+        reserveButton.addTarget(self, action: #selector(didTapReserveButton), for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [nameLabel, descriptionLabel, occupancyLabel, amenitiesLabel, checkInOutLabel, priceLabel, reserveButton])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 200),
+
+            imageStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            imageStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            imageStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            imageStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            imageStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+
+            stack.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 12),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+        ])
+    }
+
+    func configure(with room: AccommodationRoom, numberOfNights: Int) {
+        self.currentRoom = room
+        self.numberOfNights = numberOfNights
+        imageStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        for urlString in room.imageURLs {
+            let imageView = UIImageView()
+            imageView.contentMode = .scaleAspectFit
+            imageView.clipsToBounds = true
+            imageView.kf.setImage(with: URL(string: urlString))
+            imageStackView.addArrangedSubview(imageView)
+            imageView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+        }
+
+        nameLabel.text = room.name
+        descriptionLabel.text = room.description
+        occupancyLabel.text = "최대 \(room.maxOccupancy)인"
+        amenitiesLabel.text = room.amenities.prefix(3).joined(separator: ", ")
+        checkInOutLabel.text = "입실 \(room.checkInTime) · 퇴실 \(room.checkOutTime)"
+        let totalPrice = room.price * numberOfNights
+        let priceText = NSMutableAttributedString(string: "\(totalPrice.formattedWithSeparator)원 /", attributes: [
+            .foregroundColor: UIColor.black,
+            .font: UIFont.boldSystemFont(ofSize: 16)
+        ])
+        priceText.append(NSAttributedString(string: " \(numberOfNights)박", attributes: [
+            .foregroundColor: UIColor.darkGray,
+            .font: UIFont.systemFont(ofSize: 13)
+        ]))
+        priceLabel.attributedText = priceText
+        
+        let selectedGuestCount = UserDefaults.standard.integer(forKey: "selectedGuestCount")
+        if selectedGuestCount > room.maxOccupancy {
+            reserveButton.setTitle("인원 초과", for: .normal)
+            reserveButton.isEnabled = false
+            reserveButton.backgroundColor = .lightGray
+        } else {
+            reserveButton.setTitle("숙박 예약", for: .normal)
+            reserveButton.isEnabled = true
+            reserveButton.backgroundColor = UIColor(red: 47/255, green: 175/255, blue: 83/255, alpha: 1)
+        }
+    }
+
+    func updateGuestCount(_ newGuestCount: Int) {
+        guard let room = currentRoom else { return }
+
+        if newGuestCount > room.maxOccupancy {
+            reserveButton.setTitle("인원 초과", for: .normal)
+            reserveButton.isEnabled = false
+            reserveButton.backgroundColor = .lightGray
+        } else {
+            reserveButton.setTitle("숙박 예약", for: .normal)
+            reserveButton.isEnabled = true
+            reserveButton.backgroundColor = UIColor(red: 47/255, green: 175/255, blue: 83/255, alpha: 1)
+        }
+    }
+    @objc private func didTapReserveButton() {
+        guard let room = currentRoom else { return }
+        onReserveButtonTapped?(room)
+    }
+}
+
+private extension Int {
+    var formattedWithSeparator: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
+    }
+}

--- a/FaceInn/Sources/RoomCardView.swift
+++ b/FaceInn/Sources/RoomCardView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Kingfisher
+import FirebaseAuth
 
 final class RoomCardView: UIView {
 
@@ -174,7 +175,38 @@ final class RoomCardView: UIView {
     }
     @objc private func didTapReserveButton() {
         guard let room = currentRoom else { return }
+
+        if Auth.auth().currentUser == nil || Auth.auth().currentUser?.isAnonymous == true {
+            let alert = UIAlertController(title: "로그인이 필요합니다", message: "숙박 예약을 위해 로그인이 필요합니다.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: "로그인하기", style: .default, handler: { _ in
+                // Assuming the current view is embedded in a view controller
+                if let viewController = self.findViewController() {
+                    let loginVC = LoginViewController()
+                    loginVC.onLoginSuccess = {
+                        // 로그인 후 돌아오기만 함
+                    }
+                    viewController.navigationController?.pushViewController(loginVC, animated: true)
+                }
+            }))
+            if let viewController = self.findViewController() {
+                viewController.present(alert, animated: true)
+            }
+            return
+        }
+
         onReserveButtonTapped?(room)
+    }
+
+    private func findViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while let r = responder {
+            if let vc = r as? UIViewController {
+                return vc
+            }
+            responder = r.next
+        }
+        return nil
     }
 }
 

--- a/FaceInn/Sources/WishlistViewController.swift
+++ b/FaceInn/Sources/WishlistViewController.swift
@@ -56,6 +56,8 @@ final class WishlistViewController: UIViewController {
         view.subviews.filter { $0 is UILabel && ($0 as? UILabel)?.text == "로그인 후 이용해주세요" }.forEach { $0.removeFromSuperview() }
 
         guard let user = Auth.auth().currentUser, !user.isAnonymous else {
+            view.subviews.filter { $0 is UILabel && ($0 as? UILabel)?.text == "숙소를 검색하고 찜목록에 추가하세요" }.forEach { $0.removeFromSuperview() }
+
             let label = UILabel()
             label.text = "로그인 후 이용해주세요"
             label.textAlignment = .center

--- a/FaceInn/Sources/WishlistViewController.swift
+++ b/FaceInn/Sources/WishlistViewController.swift
@@ -102,7 +102,10 @@ final class WishlistViewController: UIViewController {
                         rating: data["rating"] as? Double ?? 0.0,
                         reviewCount: data["reviewCount"] as? Int ?? 0,
                         imageURLs: data["imageURLs"] as? [String],
-                        rooms: data["rooms"] as? [[String: Any]]
+                        rooms: data["rooms"] as? [[String: Any]],
+                        amenities: data["amenities"] as? [String],
+                        description: data["description"] as? String ?? "",
+                        hostId: data["hostId"] as? String ?? ""
                     )
                     loadedAccommodations.append(accommodation)
                 }

--- a/Project.swift
+++ b/Project.swift
@@ -32,6 +32,7 @@ let project = Project(
             "UIColorName": "",
             "UIImageName": "",
           ],
+          "UIUserInterfaceStyle": "Light",
           "UIApplicationSceneManifest": [
             "UIApplicationSupportsMultipleScenes": false,
             "UISceneConfigurations": [

--- a/Project.swift
+++ b/Project.swift
@@ -16,7 +16,8 @@ let project = Project(
   name: "FaceInn",
   packages: [
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", .upToNextMajor(from: "10.15.0")),
-    .package(url: "https://github.com/WenchaoD/FSCalendar", .upToNextMajor(from: "2.8.2"))
+    .package(url: "https://github.com/WenchaoD/FSCalendar", .upToNextMajor(from: "2.8.2")),
+    .package(url: "https://github.com/onevcat/Kingfisher.git", .upToNextMajor(from: "8.3.2")),
   ],
   targets: [
     .target(
@@ -53,7 +54,8 @@ let project = Project(
         .package(product: "FirebaseStorage"),
         .package(product: "FirebaseDatabase"),
         .package(product: "FirebaseMessaging"),
-        .package(product: "FSCalendar")
+        .package(product: "FSCalendar"),
+        .package(product: "Kingfisher"),
       ],
       settings: projectSettings
     ),


### PR DESCRIPTION
숙소 상세페이지 구현
- 숙박인원 보다 최대인원이 적은 객실은 숙박예약 버튼이 인원초과 라고 바뀌고 비활성화
- 숙박예약 버튼을 누르면 예약페이지로 이동
- 예약페이지에는 숙박 정보 전달
- 판매자 정보 버튼 및 View 생성, 숙소의 hostId 전달

이미지 처리 성능 개선
- 이미지 로드를 위한 kingFisher 의존성 주입

숙박 예약 로그인 유도
- 로그인을 하지 않은 상태에서 숙박예약 버튼을 탭하면 로그인 페이지로 유도 및 숙박예약 거부.
- 로그인을 하고 오면 기존 숙소상세뷰로 돌아옴